### PR TITLE
sanitizes colons away from file names for windows

### DIFF
--- a/unsourcemap.js
+++ b/unsourcemap.js
@@ -25,7 +25,7 @@ if (!fs.existsSync(outDir)) {
 }
 
 function sanitizeSourceName(url) {
-  return url.replace(/[^a-zA-Z0-9\-_.:]/g, '_');
+  return url.replace(/[^a-zA-Z0-9\-_.]/g, '_');
 }
 
 for (var i = 0; i < map.sources.length; i++) {


### PR DESCRIPTION
Windows has some problems with colons in file names. That's why I extended the file name sanitize function to also replace them with underscores.